### PR TITLE
Update docs import examples

### DIFF
--- a/docs/chapters/core.md
+++ b/docs/chapters/core.md
@@ -16,7 +16,7 @@ Record definition must:
 _Must_ be placed before record class definition.
 
 ```javascript
-import { define, Record } from 'type-r'
+import { define, Record } from '@type-r/models'
 
 @define class X extends Record {
     ...    
@@ -304,7 +304,7 @@ Record's attributes can hold other Records and Collections, forming indefinitely
 To create nested record or collection you should just mention its constructor function in attribute's definition.
 
 ```javascript
-import { Record } from 'type-r'
+import { define, Record } from '@type-r/models'
 
 @define class User extends Record {
     static attributes = {

--- a/docs/chapters/io.md
+++ b/docs/chapters/io.md
@@ -116,7 +116,7 @@ All I/O methods append an optional `options.params` object to the URL parameters
 Supports URI relative to owner (`./relative/url` resolves as `/owner/:id/relative/url/:id` ).
 
 ```javascript
-import { restfulIO } from 'type-r/endpoints/restful'
+import { restfulIO } from '@type-r/endpoints'
 
 @define class Role extends Record {
     static endpoint = restfulIO( '/api/roles' );
@@ -139,7 +139,7 @@ import { restfulIO } from 'type-r/endpoints/restful'
 Endpoint for mock testing. Takes optional array with mock data, and optional `delay` parameter which is the simulated I/O delay in milliseconds.
 
 ```javascript
-import { memoryIO } from 'type-r/endpoints/memory'
+import { memoryIO } from '@type-r/endpoints'
 
 @define class User extends Record {
     static endpoint = memoryIO();
@@ -152,7 +152,7 @@ import { memoryIO } from 'type-r/endpoints/memory'
 Endpoint for localStorage. Takes `key` parameter which must be unique for the persistent record's collection.
 
 ```javascript
-import { localStorageIO } from 'type-r/endpoints/localStorage'
+import { localStorageIO } from '@type-r/endpoints'
 
 @define class User extends Record {
     static endpoint = localStorageIO( '/users' );
@@ -167,7 +167,7 @@ Endpoint for I/O composition. Redirects record's `fetch()` request to its attrib
 It's common pattern to use attributesIO endpoint in conjunction with Store to fetch all the data required by SPA page.
 
 ```javascript
-import { localStorageIO } from 'type-r/endpoints/attributes'
+import { attributesIO } from '@type-r/endpoints'
 
 @define class PageStore extends Store {
     static endpoint = attributesIO();
@@ -191,7 +191,7 @@ an existing Record subclass as a transport. This endpoint can be connected to th
 An advantage of this approach is that JSON schema will be transparently validated on the server side by the Type-R.
 
 ```javascript
-    import { proxyIO } from 'type-r/endpoint/proxy'
+    import { proxyIO } from '@type-r/endpoints'
     
     ...
 
@@ -253,7 +253,7 @@ Service function to create an abortable version of ES6 promise (with `promise.ab
 `init` function takes the third `onAbort` argument to register an optional abort handler. If no handler is registered, the default implementation of `promise.abort()` will just reject the promise.
 
 ```javascript
-import { createIOPromise } from 'type-r'
+import { createIOPromise } from '@type-r/models'
 
 const abortablePromise = createIOPromise( ( resolve, reject, onAbort ) =>{
     ...

--- a/docs/chapters/observable.md
+++ b/docs/chapters/observable.md
@@ -176,7 +176,7 @@ Type-R uses an efficient synchronous events implementation which is backward com
 Both `source` and `listener` mentioned in method signatures must implement Events methods.
 
 ```javascript
-import { mixins, Events } from 'type-r'
+import { mixins, Events } from '@type-r/mixture'
 
 @mixins( Events )
 class EventfulClass {
@@ -299,7 +299,7 @@ change | (record, options) | The record is changed inside of collection.
 Messenger is an abstract base class implementing Events mixin and some convenience methods.
 
 ```javascript
-import { define, Messenger } from 'type-r'
+import { define, Messenger } from '@type-r/models'
 
 class MyMessenger extends Messenger {
 

--- a/docs/chapters/record.md
+++ b/docs/chapters/record.md
@@ -7,7 +7,7 @@ Records may have other records and collections of records stored in its attribut
 All aspects of an attribute behavior are controlled with attribute metadata, which (taken together with its type) is called *attribite metatype*. Metatypes can be declared separately and reused across multiple records definitions.
 
 ```javascript
-import { define, type, Record } from 'type-r'
+import { define, type, Record } from '@type-r/models'
 
 // ⤹ required to make magic work  
 @define class User extends Record {
@@ -33,7 +33,7 @@ users.updateEach( user => user.firstName = '' ); // ⟵ bulk update triggering '
 ```
 
 ```typescript
-import { define, attr, type, Record } from 'type-r'
+import { define, auto, type, value, Record, Collection } from '@type-r/models'
 import "reflect-metadata" // Required for @auto without arguments
 
 // ⤹ required to make the magic work  
@@ -237,7 +237,7 @@ If record needs to reference itself in its attributes definition, `@predefine` d
 
 Date attribute initialized as `new Date()`, and represented in JSON as UTC ISO string.
 
-There are other popular Date serialization options available in `type-r/ext-types` package.
+There are other popular Date serialization options available in the `@type-r/ext-types` package.
 
 * `MicrosoftDate` - Date serialized as Microsoft's `"/Date(msecs)/"` string.
 * `Timestamp` - Date serializaed as UNIX integer timestamp (`date.getTime()`).
@@ -289,7 +289,7 @@ Attribute definition can have different metadata attached which affects various 
 a chain of calls after the `type( Ctor )` call. Attribute's default value is the most common example of such a metadata and is the single option which can be applied to the constructor function directly.
 
 ```javascript
-import { define, type, Record }
+import { define, type, Record } from '@type-r/models'
 
 @define class Dummy extends Record {
     static attributes = {
@@ -317,7 +317,7 @@ Turns TypeScript class property definition to the record's attribute, automatica
 `@auto` may take a single parameter as an attribute default value. No other attribute metadata can be attached.
 
 ```typescript
-import { define, auto, Record } from 'type-r'
+import { define, auto, Record } from '@type-r/models'
 
 @define class User extends Record {
     @auto name : string
@@ -331,7 +331,7 @@ import { define, auto, Record } from 'type-r'
 Attribute definition creates the TypeScript property decorator when being appended with `.as` suffix. It's an alternative syntax to `@auto`.
 
 ```typescript
-import { define, type, Record } from 'type-r'
+import { define, type, value, Record } from '@type-r/models'
 
 @define class User extends Record {
     @value( "5" ).as name : string
@@ -551,7 +551,7 @@ Record's attributes can hold other Records and Collections, forming indefinitely
 To create nested record or collection you should just mention its constructor function in attribute's definition.
 
 ```javascript
-import { Record } from 'type-r'
+import { define, Record } from '@type-r/models'
 
 @define class User extends Record {
     static attributes = {

--- a/docs/chapters/releasenotes.md
+++ b/docs/chapters/releasenotes.md
@@ -21,14 +21,14 @@ construct from object/array | - | `RecordOrCollectionClass.from( json, options? 
 
 Starting from version 3.X, Type-R does not modify built-in global JS objects. New `type(T)` attribute definition notation is introduced to replace `T.has.`
 
-There's `type-r/globals` package for compatibility with version 2.x which must be imported once with `import 'type-r/globals'`.
+There's `@type-r/globals` package for compatibility with version 2.x which must be imported once with `import '@type-r/globals'`.
 If this package is not used, the code must be refactored according to the rules below.
 
 | 2.x | 3.x
  -|-|-
-UNIX Timestamp | `Date.timestamp` | `import { Timestamp } from 'type-r/ext-types'`
-Microsoft date | `Date.microsoft` | `import { MicrosoftDate } from 'type-r/ext-types'`
-Integer | `Integer` and `Number.integer` | `import { Integer } from 'type-r/ext-types'`
+UNIX Timestamp | `Date.timestamp` | `import { Timestamp } from '@type-r/ext-types'`
+Microsoft date | `Date.microsoft` | `import { MicrosoftDate } from '@type-r/ext-types'`
+Integer | `Integer` and `Number.integer` | `import { Integer } from '@type-r/ext-types'`
 Create metatype from constructor | `Ctor.has` | `type(Ctor)`
 Typed attribute with default value | `Ctor.value(default)` | `type(Ctor).value(default)`
 Attribute "Required" check | `Ctor.isRequired` | `type(Ctor).required`

--- a/docs/chapters/tools.md
+++ b/docs/chapters/tools.md
@@ -16,7 +16,7 @@ The `level` corresponds to the logging methods of the `console` object: `error`,
 If you want to use Type-R
 
 ```javascript
-import { log } from 'type-r'
+import { log } from '@type-r/mixture'
 
 log( 'error', 'client-api:users', 'No user with the given id', { user } );
 ```
@@ -24,7 +24,7 @@ log( 'error', 'client-api:users', 'No user with the given id', { user } );
 ### logger.off()
 
 ```javascript
-import { logger } from 'type-r'
+import { logger } from '@type-r/mixture'
 
 // Remove all the listeners
 logger.off();
@@ -38,7 +38,7 @@ logger.off( 'warn' );
 Sometimes (for instance, in a test suite) developer would like Type-R to throw exceptions on type errors instead of the console warnings.
 
 ```javascript
-import { logger } from 'type-r'
+import { logger } from '@type-r/mixture'
 
 logger.off().throwOn( 'error' ).throwOn( 'warn' );
 ```
@@ -46,7 +46,7 @@ logger.off().throwOn( 'error' ).throwOn( 'warn' );
 Or, there might be a need to throw exceptions on error in the specific situation (e.g. throw if the incoming HTTP request is not valid to respond with 500 HTTP code).
 
 ```javascript
-import { Logger } from 'type-r'
+import { Logger } from '@type-r/mixture'
 
 async function processRequest( ... ){
     // Create an empty logger
@@ -66,7 +66,7 @@ async function processRequest( ... ){
 Type-R log message is the regular event. It's easy to attach custom listeners to integrate third-party log management libraries.
 
 ```javascript
-import { logger } from 'type-r'
+import { logger } from '@type-r/mixture'
 
 logger
     .off()
@@ -213,7 +213,7 @@ Finalized the class definition started with `@predefine` decorator. Has the same
 Merge specified mixins to the class definition. Both plain JS object and class constructor may be used as mixin. In the case of the class constructor, missing static members will copied over as well.
 
 ```javascript
-    import { mixins, Events } from 'type-r'
+    import { mixins, Events } from '@type-r/mixture'
     ...
 
     @define

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,9 +84,9 @@
 <p><img src="images/3-layer-client.png" alt="overview"></p>
 <p>A state is defined as a superposition of typed records and collections. A record is a class with a known set of attributes of predefined types possibly holding other records and collections in its attributes, describing the data structure of arbitrary complexity. Record with its attributes forms an aggregation tree with deeply observable attributes changes. Attribute types are checked on assignments and invalid changes are being rejected, therefore it is guaranteed that the application state will preserve the valid shape.</p>
 <p>Application state defined with Type-R is serializable to JSON by default. Aggregation tree of records and collections is mapped in JSON as a tree of plain objects and arrays. Normalized data represented as a set of collections of records cross-referencing each other are supported as first-class serialization scenario.</p>
-<p>A record may have an associated IOEndpont representing the I/O protocol for CRUD and collection fetch operations which enables the persistence API for the particular record/collection class pair. Some useful endpoints (<code>restfulIO</code>, <code>localStorageIO</code>, etc) are provided by <code>type-r/endpoints/*</code> packages, and developers can define their own I/O endpoints implementing any particular persistence transport or API.</p>
+<p>A record may have an associated IOEndpont representing the I/O protocol for CRUD and collection fetch operations which enables the persistence API for the particular record/collection class pair. Some useful endpoints (<code>restfulIO</code>, <code>localStorageIO</code>, etc) are provided by the <code>@type-r/endpoints</code> package, and developers can define their own I/O endpoints implementing any particular persistence transport or API.</p>
 <p>Record attributes may have custom validation rules attached to them. Validation is being triggered transparently on demand and its result is cached across the record/collection aggregation tree, making subsequent calls to the validation API extremely cheap.</p>
-<p>All aspects of record behavior including serialization and validation can be controlled on attribute level with declarative definitions combining attribute types with metadata. Attribute definitions (&quot;metatypes&quot;) can be reused across different models forming the domain-specific language of model declarations. Some useful attribute metatypes (<code>Email</code>, <code>Url</code>, <code>MicrosoftDate</code>, etc) are provided by <code>type-r/ext-types</code> package.</p>
+<p>All aspects of record behavior including serialization and validation can be controlled on attribute level with declarative definitions combining attribute types with metadata. Attribute definitions (&quot;metatypes&quot;) can be reused across different models forming the domain-specific language of model declarations. Some useful attribute metatypes (<code>Email</code>, <code>Url</code>, <code>MicrosoftDate</code>, etc) are provided by the <code>@type-r/ext-types</code> package.</p>
 <h2 id="how-type-r-compares-to-x-">How Type-R compares to X?</h2>
 <p>Type-R (former &quot;NestedTypes&quot;) project was started in 2014 in Volicon as a modern successor to BackboneJS models, which would match Ember Data in its capabilities to work with a complex state while retaining the BackboneJS simplicity, modularity, and some degree of backward API compatibility. It replaced BackboneJS in the model layer of Volicon products, and it became the key technology in Volicon&#39;s strategy to gradually move from BackboneJS Views to React in the view layer.</p>
 <p><a href="https://guides.emberjs.com/v2.2.0/models/">Ember Data</a> is the closest thing to Type-R by its capabilities, with <a href="http://backbonejs.org/#Model">BackboneJS models and collections</a> being the closest thing by the API, and <a href="https://github.com/mobxjs/mobx">mobx</a> being pretty close in the way how the UI state is managed.</p>
@@ -311,7 +311,7 @@ expect( users.isValid() ).toBe( <span class="hljs-literal">true</span> );
 <p>Record is an optionally persistent class having the predefined set of attributes. Each attribute is the property of known type which is protected from improper assigments at run-time, is serializable to JSON by default, has deeply observable changes, and may have custom validation rules attached.</p>
 <p>Records may have other records and collections of records stored in its attributes describing an application state of an arbitrary complexity. These nested records and collections are considered to be an integral part of the parent record forming an <em>aggregation tree</em> which can be serialized to JSON, cloned, and disposed of as a whole.</p>
 <p>All aspects of an attribute behavior are controlled with attribute metadata, which (taken together with its type) is called <em>attribite metatype</em>. Metatypes can be declared separately and reused across multiple records definitions.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, type, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, type, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 <span class="hljs-comment">// ⤹ required to make magic work  </span>
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">User</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
@@ -335,7 +335,7 @@ users.on( <span class="hljs-string">'changes'</span>, () =&gt; updateUI( users )
 users.set( json, { <span class="hljs-attr">parse</span> : <span class="hljs-literal">true</span> } ); <span class="hljs-comment">// ⟵ parse raw JSON from the server.</span>
 users.updateEach( <span class="hljs-function"><span class="hljs-params">user</span> =&gt;</span> user.firstName = <span class="hljs-string">''</span> ); <span class="hljs-comment">// ⟵ bulk update triggering 'changes' once</span>
 </code></pre>
-<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, attr, <span class="hljs-keyword">type</span>, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, auto, <span class="hljs-keyword">type</span>, value, Record, Collection } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 <span class="hljs-keyword">import</span> <span class="hljs-string">"reflect-metadata"</span> <span class="hljs-comment">// Required for @auto without arguments</span>
 
 <span class="hljs-comment">// ⤹ required to make the magic work  </span>
@@ -495,7 +495,7 @@ Use the general form of attribute definition in such cases: <code>value( theFunc
 <p>If record needs to reference itself in its attributes definition, <code>@predefine</code> decorator with subsequent <code>MyRecord.define()</code> needs to be used.</p>
 <h3 id="attrdef-date"><code>attrDef</code> : Date</h3>
 <p>Date attribute initialized as <code>new Date()</code>, and represented in JSON as UTC ISO string.</p>
-<p>There are other popular Date serialization options available in <code>type-r/ext-types</code> package.</p>
+<p>There are other popular Date serialization options available in the <code>@type-r/ext-types</code> package.</p>
 <ul>
 <li><code>MicrosoftDate</code> - Date serialized as Microsoft&#39;s <code>&quot;/Date(msecs)/&quot;</code> string.</li>
 <li><code>Timestamp</code> - Date serializaed as UNIX integer timestamp (<code>date.getTime()</code>).</li>
@@ -535,7 +535,7 @@ Use the general form of attribute definition in such cases: <code>value( theFunc
 <h3 id="attrdef-type-type-"><code>attrDef</code> type(Type)</h3>
 <p>Attribute definition can have different metadata attached which affects various aspects of attribute&#39;s behavior. Metadata is attached with
 a chain of calls after the <code>type( Ctor )</code> call. Attribute&#39;s default value is the most common example of such a metadata and is the single option which can be applied to the constructor function directly.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, type, Record }
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, type, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Dummy</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
     <span class="hljs-keyword">static</span> attributes = {
@@ -554,7 +554,7 @@ a chain of calls after the <code>type( Ctor )</code> call. Attribute&#39;s defau
 <h3 id="decorator-auto"><code>decorator</code> @auto</h3>
 <p>Turns TypeScript class property definition to the record&#39;s attribute, automatically extracting attribute type from the TypeScript type annotation. Requires <code>reflect-metadata</code> npm package and <code>emitDecoratorMetadata</code> option set to true in the <code>tsconfig.json</code>.</p>
 <p><code>@auto</code> may take a single parameter as an attribute default value. No other attribute metadata can be attached.</p>
-<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, auto, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, auto, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 <span class="hljs-meta">@define</span> <span class="hljs-keyword">class</span> User <span class="hljs-keyword">extends</span> Record {
     <span class="hljs-meta">@auto</span> name : <span class="hljs-built_in">string</span>
@@ -564,7 +564,7 @@ a chain of calls after the <code>type( Ctor )</code> call. Attribute&#39;s defau
 </code></pre>
 <h3 id="decorator-attrdef-as"><code>decorator</code> @<code>attrDef</code>.as</h3>
 <p>Attribute definition creates the TypeScript property decorator when being appended with <code>.as</code> suffix. It&#39;s an alternative syntax to <code>@auto</code>.</p>
-<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, <span class="hljs-keyword">type</span>, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight typescript"><span class="hljs-keyword">import</span> { define, <span class="hljs-keyword">type</span>, value, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 <span class="hljs-meta">@define</span> <span class="hljs-keyword">class</span> User <span class="hljs-keyword">extends</span> Record {
     <span class="hljs-meta">@value</span>( <span class="hljs-string">"5"</span> ).as name : <span class="hljs-built_in">string</span>
@@ -720,7 +720,7 @@ Any additional changes made to the record in <code>change:attr</code> event hand
 <h2 id="nested-records-and-collections">Nested records and collections</h2>
 <p>Record&#39;s attributes can hold other Records and Collections, forming indefinitely nested data structures of arbitrary complexity.
 To create nested record or collection you should just mention its constructor function in attribute&#39;s definition.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, Record } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">User</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
     <span class="hljs-keyword">static</span> attributes = {
@@ -1254,7 +1254,7 @@ Any additional changes made to the collection or its items in event handlers wil
 <p>Type-R uses an efficient synchronous events implementation which is backward compatible with Backbone 1.1 Events API but is about twice faster in all major browsers. It comes in form of <code>Events</code> mixin and the <code>Messenger</code> base class.</p>
 <p><code>Events</code> is a <a href="#mixins">mixin</a> giving the object the ability to bind and trigger custom named events. Events do not have to be declared before they are bound, and may take passed arguments.</p>
 <p>Both <code>source</code> and <code>listener</code> mentioned in method signatures must implement Events methods.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { mixins, Events } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { mixins, Events } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 @mixins( Events )
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">EventfulClass</span> </span>{
@@ -1393,7 +1393,7 @@ Any additional changes made to the collection or its items in event handlers wil
 </table>
 <h2 id="messenger-class">Messenger class</h2>
 <p>Messenger is an abstract base class implementing Events mixin and some convenience methods.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, Messenger } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { define, Messenger } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyMessenger</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Messenger</span> </span>{
 
@@ -1566,7 +1566,7 @@ No built-in I/O enpoints support that functionality yet.
 <li><code>record.destroy()</code> makes <code>DELETE url</code>.</li>
 </ul>
 <p>Supports URI relative to owner (<code>./relative/url</code> resolves as <code>/owner/:id/relative/url/:id</code> ).</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { restfulIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r/endpoints/restful'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { restfulIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/endpoints'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Role</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
     <span class="hljs-keyword">static</span> endpoint = restfulIO( <span class="hljs-string">'/api/roles'</span> );
@@ -1585,7 +1585,7 @@ No built-in I/O enpoints support that functionality yet.
 </code></pre>
 <h3 id="memoryio-mockdata-delay-">memoryIO( mockData?, delay? )</h3>
 <p>Endpoint for mock testing. Takes optional array with mock data, and optional <code>delay</code> parameter which is the simulated I/O delay in milliseconds.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { memoryIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r/endpoints/memory'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { memoryIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/endpoints'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">User</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
     <span class="hljs-keyword">static</span> endpoint = memoryIO();
@@ -1594,7 +1594,7 @@ No built-in I/O enpoints support that functionality yet.
 </code></pre>
 <h3 id="localstorageio-key-">localStorageIO( key )</h3>
 <p>Endpoint for localStorage. Takes <code>key</code> parameter which must be unique for the persistent record&#39;s collection.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { localStorageIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r/endpoints/localStorage'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { localStorageIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/endpoints'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">User</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Record</span> </span>{
     <span class="hljs-keyword">static</span> endpoint = localStorageIO( <span class="hljs-string">'/users'</span> );
@@ -1604,7 +1604,7 @@ No built-in I/O enpoints support that functionality yet.
 <h3 id="attributesio-">attributesIO()</h3>
 <p>Endpoint for I/O composition. Redirects record&#39;s <code>fetch()</code> request to its attributes and returns the combined abortable promise. Does not enable any other I/O methods and can be used with <code>record.fetch()</code> only.</p>
 <p>It&#39;s common pattern to use attributesIO endpoint in conjunction with Store to fetch all the data required by SPA page.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { localStorageIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r/endpoints/attributes'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { attributesIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/endpoints'</span>
 
 @define <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">PageStore</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Store</span> </span>{
     <span class="hljs-keyword">static</span> endpoint = attributesIO();
@@ -1622,7 +1622,7 @@ store.fetch().then( <span class="hljs-function"><span class="hljs-params">()</sp
 <p>Assuming that you have Type-R records with endpoints working with the database, you can create an endpoint which will use
 an existing Record subclass as a transport. This endpoint can be connected to the RESTful endpoint API on the server side which will serve JSON to the restfulIO endpoint on the client.</p>
 <p>An advantage of this approach is that JSON schema will be transparently validated on the server side by the Type-R.</p>
-<pre><code class="highlight javascript">    <span class="hljs-keyword">import</span> { proxyIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r/endpoint/proxy'</span>
+<pre><code class="highlight javascript">    <span class="hljs-keyword">import</span> { proxyIO } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/endpoints'</span>
 
     ...
 
@@ -1658,7 +1658,7 @@ an existing Record subclass as a transport. This endpoint can be connected to th
 <h3 id="createiopromise-init-">createIOPromise( init )</h3>
 <p>Service function to create an abortable version of ES6 promise (with <code>promise.abort()</code> which meant to stop pending I/O and reject the promise).</p>
 <p><code>init</code> function takes the third <code>onAbort</code> argument to register an optional abort handler. If no handler is registered, the default implementation of <code>promise.abort()</code> will just reject the promise.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { createIOPromise } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { createIOPromise } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/models'</span>
 
 <span class="hljs-keyword">const</span> abortablePromise = createIOPromise( <span class="hljs-function">(<span class="hljs-params"> resolve, reject, onAbort </span>) =&gt;</span>{
     ...
@@ -1856,12 +1856,12 @@ Store.global = <span class="hljs-keyword">new</span> MyStore();
 <p>The <code>level</code> corresponds to the logging methods of the <code>console</code> object: <code>error</code>, <code>warn</code>, <code>info</code>, <code>log</code>, <code>debug</code>.</p>
 <p><code>topic</code> is the short string used to denote the log source source and functional area. Type-R topics are prefixed with <code>TR</code>, and looks like <code>TR:TypeError</code>.
 If you want to use Type-R</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { log } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { log } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 log( <span class="hljs-string">'error'</span>, <span class="hljs-string">'client-api:users'</span>, <span class="hljs-string">'No user with the given id'</span>, { user } );
 </code></pre>
 <h3 id="logger-off-">logger.off()</h3>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 <span class="hljs-comment">// Remove all the listeners</span>
 logger.off();
@@ -1871,12 +1871,12 @@ logger.off( <span class="hljs-string">'warn'</span> );
 </code></pre>
 <h3 id="logger-throwon-level-">logger.throwOn( level )</h3>
 <p>Sometimes (for instance, in a test suite) developer would like Type-R to throw exceptions on type errors instead of the console warnings.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 logger.off().throwOn( <span class="hljs-string">'error'</span> ).throwOn( <span class="hljs-string">'warn'</span> );
 </code></pre>
 <p>Or, there might be a need to throw exceptions on error in the specific situation (e.g. throw if the incoming HTTP request is not valid to respond with 500 HTTP code).</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { Logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { Logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 <span class="hljs-keyword">async</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">processRequest</span>(<span class="hljs-params"> ... </span>)</span>{
     <span class="hljs-comment">// Create an empty logger</span>
@@ -1892,7 +1892,7 @@ logger.off().throwOn( <span class="hljs-string">'error'</span> ).throwOn( <span 
 </code></pre>
 <h3 id="logger-on-level-handler-">logger.on( level, handler )</h3>
 <p>Type-R log message is the regular event. It&#39;s easy to attach custom listeners to integrate third-party log management libraries.</p>
-<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript"><span class="hljs-keyword">import</span> { logger } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
 
 logger
     .off()
@@ -2002,7 +2002,7 @@ In other aspects, it behaves the same as the <code>@default</code> decorator wit
 <h2 id="mixins">Mixins</h2>
 <h3 id="decorator-mixins-mixina-mixinb-class-x-"><code>decorator</code> @mixins( mixinA, mixinB, ... ) class X ...</h3>
 <p>Merge specified mixins to the class definition. Both plain JS object and class constructor may be used as mixin. In the case of the class constructor, missing static members will copied over as well.</p>
-<pre><code class="highlight javascript">    <span class="hljs-keyword">import</span> { mixins, Events } <span class="hljs-keyword">from</span> <span class="hljs-string">'type-r'</span>
+<pre><code class="highlight javascript">    <span class="hljs-keyword">import</span> { mixins, Events } <span class="hljs-keyword">from</span> <span class="hljs-string">'@type-r/mixture'</span>
     ...
 
     @define
@@ -2122,7 +2122,7 @@ x.componentWillMount();
 </table>
 <h3 id="new-attribute-definition-notation">New attribute definition notation</h3>
 <p>Starting from version 3.X, Type-R does not modify built-in global JS objects. New <code>type(T)</code> attribute definition notation is introduced to replace <code>T.has.</code></p>
-<p>There&#39;s <code>type-r/globals</code> package for compatibility with version 2.x which must be imported once with <code>import &#39;type-r/globals&#39;</code>.
+<p>There&#39;s <code>@type-r/globals</code> package for compatibility with version 2.x which must be imported once with <code>import &#39;@type-r/globals&#39;</code>.
 If this package is not used, the code must be refactored according to the rules below.</p>
 <table>
 <thead>
@@ -2136,17 +2136,17 @@ If this package is not used, the code must be refactored according to the rules 
 <tr>
 <td>UNIX Timestamp</td>
 <td><code>Date.timestamp</code></td>
-<td><code>import { Timestamp } from &#39;type-r/ext-types&#39;</code></td>
+<td><code>import { Timestamp } from &#39;@type-r/ext-types&#39;</code></td>
 </tr>
 <tr>
 <td>Microsoft date</td>
 <td><code>Date.microsoft</code></td>
-<td><code>import { MicrosoftDate } from &#39;type-r/ext-types&#39;</code></td>
+<td><code>import { MicrosoftDate } from &#39;@type-r/ext-types&#39;</code></td>
 </tr>
 <tr>
 <td>Integer</td>
 <td><code>Integer</code> and <code>Number.integer</code></td>
-<td><code>import { Integer } from &#39;type-r/ext-types&#39;</code></td>
+<td><code>import { Integer } from &#39;@type-r/ext-types&#39;</code></td>
 </tr>
 <tr>
 <td>Create metatype from constructor</td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,11 +39,11 @@ A state is defined as a superposition of typed records and collections. A record
 
 Application state defined with Type-R is serializable to JSON by default. Aggregation tree of records and collections is mapped in JSON as a tree of plain objects and arrays. Normalized data represented as a set of collections of records cross-referencing each other are supported as first-class serialization scenario.
 
-A record may have an associated IOEndpont representing the I/O protocol for CRUD and collection fetch operations which enables the persistence API for the particular record/collection class pair. Some useful endpoints (`restfulIO`, `localStorageIO`, etc) are provided by `type-r/endpoints/*` packages, and developers can define their own I/O endpoints implementing any particular persistence transport or API.
+A record may have an associated IOEndpont representing the I/O protocol for CRUD and collection fetch operations which enables the persistence API for the particular record/collection class pair. Some useful endpoints (`restfulIO`, `localStorageIO`, etc) are provided by the `@type-r/endpoints` package, and developers can define their own I/O endpoints implementing any particular persistence transport or API.
 
 Record attributes may have custom validation rules attached to them. Validation is being triggered transparently on demand and its result is cached across the record/collection aggregation tree, making subsequent calls to the validation API extremely cheap.
 
-All aspects of record behavior including serialization and validation can be controlled on attribute level with declarative definitions combining attribute types with metadata. Attribute definitions ("metatypes") can be reused across different models forming the domain-specific language of model declarations. Some useful attribute metatypes (`Email`, `Url`, `MicrosoftDate`, etc) are provided by `type-r/ext-types` package.
+All aspects of record behavior including serialization and validation can be controlled on attribute level with declarative definitions combining attribute types with metadata. Attribute definitions ("metatypes") can be reused across different models forming the domain-specific language of model declarations. Some useful attribute metatypes (`Email`, `Url`, `MicrosoftDate`, etc) are provided by the `@type-r/ext-types` package.
 
 ## How Type-R compares to X?
 


### PR DESCRIPTION
## Summary

Update API documentation import examples to use the current scoped `@type-r/*` packages instead of legacy `type-r` package paths.

## Changes

- Replace model/core imports with `@type-r/models`.
- Replace endpoint imports with the `@type-r/endpoints` barrel package.
- Replace logging, events, and mixin imports with `@type-r/mixture`.
- Replace ext-type examples with `@type-r/ext-types`.
- Replace globals compatibility reference with `@type-r/globals`.
- Fix the `attributesIO` example import, which previously showed `localStorageIO`.
- Add missing symbols in one TypeScript example import: `auto`, `value`, and `Collection`.
- Refresh generated `docs/index.html`.

## Verification

- `node docs/build.js`
  - passed
